### PR TITLE
fix PostgreSQL 18

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -12,7 +12,7 @@ services:
       POSTGRES_PASSWORD: ${PG_PASSWORD}
       POSTGRES_DATABASE: ${PG_DATABASE}
     volumes:
-      - ./db_data:/var/lib/postgresql/data/
+      - ./db_data:/var/lib/postgresql/
     healthcheck:
       test: ["CMD", "pg_isready", "-p", "5432", "-U", "${PG_USER}"]
       interval: 5s


### PR DESCRIPTION
Fixed the Error: 

mlflow_db      | Error: in 18+, these Docker images are configured to store database data in a
mlflow_db      |        format which is compatible with "pg_ctlcluster" (specifically, using
mlflow_db      |        major-version-specific directory names).  This better reflects how
mlflow_db      |        PostgreSQL itself works, and how upgrades are to be performed.
mlflow_db      | 
mlflow_db      |        See also https://github.com/docker-library/postgres/pull/1259
mlflow_db      | 
mlflow_db      |        Counter to that, there appears to be PostgreSQL data in:
mlflow_db      |          /var/lib/postgresql/data (unused mount/volume)




Information:
Source: https://hub.docker.com/_/postgres#pgdata

 **PGDATA**

> Important Change: [the PGDATA environment variable of the image was changed to be version specific in PostgreSQL 18 and above⁠](https://github.com/docker-library/postgres/pull/1259). For 18 it is /var/lib/postgresql/18/docker. Later versions will replace 18 with their respective major version (e.g., /var/lib/postgresql/19/docker for PostgreSQL 19.x). The defined VOLUME was changed in 18 and above to /var/lib/postgresql. Mounts and volumes should be targeted at the updated location. This will allow users upgrading between PostgreSQL major releases to use the faster --link when running pg_upgrade and mounting /var/lib/postgresql

Users who wish to opt-in to this change on older releases can do so by setting PGDATA explicitly (--env PGDATA=/var/lib/postgresql/17/docker --volume some-postgres:/var/lib/postgresql). To migrate pre-existing data, adjust the volume's folder structure appropriately first (moving all database files into a PG_MAJOR/docker subdirectory).

> Important Note: (for PostgreSQL 17 and below) Mount the data volume at /var/lib/postgresql/data and not at /var/lib/postgresql because mounts at the latter path WILL NOT PERSIST database data when the container is re-created. The Dockerfile that builds the image declares a volume at /var/lib/postgresql/data and if no data volume is mounted at that path then the container runtime will automatically create an [anonymous volume⁠](https://docs.docker.com/engine/storage/#volumes) that is not reused across container re-creations. Data will be written to the anonymous volume rather than your intended data volume and won't persist when the container is deleted and re-created.

This (PGDATA) is an environment variable that is not Docker specific. Because the variable is used by the postgres server binary (see the [PostgreSQL docs⁠](https://www.postgresql.org/docs/14/app-postgres.html#id-1.9.5.14.7)), the entrypoint script takes it into account.

Source: https://hub.docker.com/_/postgres#pgdata
